### PR TITLE
refactor: ビルドからアーキテクチャ名を削除

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -14,19 +14,12 @@ if [[ -z "$VERSION" ]]; then
     VERSION="1.0.0"
 fi
 
-# アーキテクチャ検出
-ARCH=$(uname -m)
-case "$ARCH" in
-    x86_64) ARCH="x86_64" ;;
-    aarch64|arm64) ARCH="arm64" ;;
-    *) ARCH="unknown" ;;
-esac
-
+# OS検出（アーキテクチャは不要 - 純粋なBashスクリプトのため）
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 
 # 出力設定
 DIST_DIR="$PROJECT_ROOT/dist"
-ARCHIVE_NAME="ignite-v${VERSION}-${OS}-${ARCH}"
+ARCHIVE_NAME="ignite-v${VERSION}-${OS}"
 BUILD_DIR="$DIST_DIR/$ARCHIVE_NAME"
 
 # カラー定義
@@ -61,7 +54,7 @@ IGNITE ビルドスクリプト
   -h, --help       このヘルプを表示
 
 出力:
-  dist/ignite-v${VERSION}-${OS}-${ARCH}.tar.gz
+  dist/ignite-v${VERSION}-${OS}.tar.gz
 
 例:
   ./scripts/build.sh
@@ -239,7 +232,7 @@ main() {
         case "$1" in
             --version)
                 VERSION="$2"
-                ARCHIVE_NAME="ignite-v${VERSION}-${OS}-${ARCH}"
+                ARCHIVE_NAME="ignite-v${VERSION}-${OS}"
                 BUILD_DIR="$DIST_DIR/$ARCHIVE_NAME"
                 shift 2
                 ;;
@@ -268,7 +261,6 @@ main() {
     print_header "IGNITE ビルド v${VERSION}"
     echo ""
     echo "OS: $OS"
-    echo "Arch: $ARCH"
     echo "Output: $DIST_DIR/${ARCHIVE_NAME}.tar.gz"
     echo ""
 


### PR DESCRIPTION
## Summary
純粋なBashスクリプトのためアーキテクチャ依存がないことから、ビルド出力ファイル名をシンプル化しました。

## 変更内容

| 変更前 | 変更後 |
|-------|-------|
| `ignite-v1.0.0-linux-arm64.tar.gz` | `ignite-v1.0.0-linux.tar.gz` |
| `ignite-v1.0.0-linux-x86_64.tar.gz` | `ignite-v1.0.0-linux.tar.gz` |

## 理由
- IGNITEは純粋なBashスクリプトで構成
- ARM64/x86_64の区別は実質的に不要
- ファイル名のシンプル化でダウンロード・配布が簡単に

## 削除した部分
```bash
# 削除: アーキテクチャ検出
ARCH=$(uname -m)
case "$ARCH" in
    x86_64) ARCH="x86_64" ;;
    aarch64|arm64) ARCH="arm64" ;;
    *) ARCH="unknown" ;;
esac
```

## Test plan
- [x] `./scripts/build.sh` でビルド成功確認
- [x] 出力ファイル: `ignite-v1.0.0-linux.tar.gz`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)