### PR TITLE
docs(config): 相対パスの基準ディレクトリを明記

### DIFF
--- a/config/github-watcher.yaml.example
+++ b/config/github-watcher.yaml.example
@@ -48,10 +48,12 @@ watcher:
 
   # 処理済みイベントの保存先
   # 重複処理を防ぐためのステートファイル
+  # 注: プロジェクトルート（ignite/）からの相対パス
   state_file: "workspace/state/github_watcher_state.json"
 
   # ワークスペースディレクトリ
   # イベントメッセージの出力先
+  # 注: プロジェクトルート（ignite/）からの相対パス
   workspace: "workspace"
 
 # トリガー設定
@@ -165,4 +167,5 @@ logging:
   level: info
 
   # ログファイル（空の場合は標準出力のみ）
+  # 注: プロジェクトルート（ignite/）からの相対パス
   file: "workspace/logs/github_watcher.log"


### PR DESCRIPTION
## Summary
- `github-watcher.yaml.example` のパス設定にコメントを追加
- `state_file`, `workspace`, `file` がプロジェクトルート（ignite/）からの相対パスであることを明記

Fixes #21

## Test plan
- [x] コメントが正しく追加されていることを確認
- [x] YAML構文が壊れていないことを確認（構造変更なし、コメント追加のみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)