### PR TITLE
fix: インストールモードでWatcher設定ファイルが見つからないバグを修正

### DIFF
--- a/scripts/ignite
+++ b/scripts/ignite
@@ -606,7 +606,8 @@ EOF
             print_info "GitHub Watcherを起動中..."
             # ログ出力先を設定してバックグラウンド起動
             local watcher_log="$WORKSPACE_DIR/logs/github_watcher.log"
-            "$IGNITE_SCRIPTS_DIR/utils/github_watcher.sh" >> "$watcher_log" 2>&1 &
+            IGNITE_WATCHER_CONFIG="$IGNITE_CONFIG_DIR/github-watcher.yaml" \
+                "$IGNITE_SCRIPTS_DIR/utils/github_watcher.sh" >> "$watcher_log" 2>&1 &
             local watcher_pid=$!
             echo "$watcher_pid" > "$WORKSPACE_DIR/github_watcher.pid"
             print_success "GitHub Watcher起動完了 (PID: $watcher_pid)"


### PR DESCRIPTION
## Summary

- インストールモードで `ignite start --with-watcher` を実行すると設定ファイルが見つからないエラーが発生するバグを修正
- `github_watcher.sh` 呼び出し時に `IGNITE_WATCHER_CONFIG` 環境変数を設定するように変更

## 問題

```
[ERROR] 設定ファイルが見つかりません: /home/taz/.local/share/ignite/config/github-watcher.yaml
```

- **期待されるパス:** `~/.config/ignite/github-watcher.yaml`
- **実際に探索していたパス:** `~/.local/share/ignite/config/github-watcher.yaml`

## Test plan

- [ ] インストールモードで `ignite start --with-watcher` を実行
- [ ] `tail -f logs/github_watcher.log` でエラーが出ないことを確認
- [ ] `ignite status` で watcher が running と表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)