### PR TITLE
refactor: 共通モジュールと設定可能な待機時間を追加

### DIFF
--- a/config/system.yaml
+++ b/config/system.yaml
@@ -18,8 +18,13 @@ paths:
   logs: ./workspace/logs
 
 claude_code:
-  command: "claude-code --dangerously-skip-permissions"
-  startup_delay: 3  # seconds to wait after launching
+  command: "claude --dangerously-skip-permissions"
+  # エージェント起動時の待機時間設定（秒）
+  delays:
+    startup: 3        # Claude CLI 起動後の待機
+    permission: 0.5   # 権限チェック時の待機
+    init: 8           # Claude Code 初期化完了までの待機
+    prompt: 2         # プロンプト送信後の安定化待機
 
 monitoring:
   dashboard_update_interval: 5  # seconds

--- a/scripts/utils/common.sh
+++ b/scripts/utils/common.sh
@@ -1,0 +1,192 @@
+#!/bin/bash
+# =============================================================================
+# IGNITE 共通モジュール
+# カラー定義、ログ関数、XDGパス解決などの共通機能を提供
+# =============================================================================
+#
+# 使用方法:
+#   source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
+#
+# 提供する機能:
+#   - カラー定義 (GREEN, BLUE, YELLOW, RED, CYAN, BOLD, NC)
+#   - ログ関数 (log_info, log_success, log_warn, log_error)
+#   - XDGパス解決 (resolve_ignite_paths)
+#   - 移植性のある sed -i (sed_inplace)
+#
+# =============================================================================
+
+# =============================================================================
+# カラー定義
+# =============================================================================
+
+# ターミナルがカラーをサポートしているか確認
+if [[ -t 1 ]] && [[ "${TERM:-}" != "dumb" ]]; then
+    GREEN='\033[0;32m'
+    BLUE='\033[0;34m'
+    YELLOW='\033[1;33m'
+    RED='\033[0;31m'
+    CYAN='\033[0;36m'
+    BOLD='\033[1m'
+    NC='\033[0m'
+else
+    # 非対話モードではカラーを無効化
+    GREEN=''
+    BLUE=''
+    YELLOW=''
+    RED=''
+    CYAN=''
+    BOLD=''
+    NC=''
+fi
+
+# =============================================================================
+# ログ関数
+# =============================================================================
+
+# タイムスタンプ付きログ出力
+log_info() {
+    echo -e "[$(date '+%Y-%m-%d %H:%M:%S')] ${BLUE}[INFO]${NC} $1"
+}
+
+log_success() {
+    echo -e "[$(date '+%Y-%m-%d %H:%M:%S')] ${GREEN}[OK]${NC} $1"
+}
+
+log_warn() {
+    echo -e "[$(date '+%Y-%m-%d %H:%M:%S')] ${YELLOW}[WARN]${NC} $1"
+}
+
+log_error() {
+    echo -e "[$(date '+%Y-%m-%d %H:%M:%S')] ${RED}[ERROR]${NC} $1" >&2
+}
+
+# シンプルなログ出力（タイムスタンプなし）
+print_info() {
+    echo -e "${BLUE}$1${NC}"
+}
+
+print_success() {
+    echo -e "${GREEN}✓ $1${NC}"
+}
+
+print_warning() {
+    echo -e "${YELLOW}⚠ $1${NC}"
+}
+
+print_error() {
+    echo -e "${RED}✗ $1${NC}" >&2
+}
+
+print_header() {
+    echo -e "${BOLD}=== $1 ===${NC}"
+}
+
+# =============================================================================
+# XDGパス解決
+# =============================================================================
+
+# IGNITE のパスを解決する
+# インストールモード（~/.config/ignite/.install_paths が存在）と
+# 開発モード（PROJECT_ROOT を使用）を自動判定
+#
+# 設定される変数:
+#   IGNITE_CONFIG_DIR - 設定ファイルディレクトリ
+#   IGNITE_DATA_DIR   - データディレクトリ
+#   IGNITE_INSTALLED_MODE - true/false
+#
+# 引数:
+#   $1 - PROJECT_ROOT (オプション、開発モード時のフォールバック)
+#
+resolve_ignite_paths() {
+    local project_root="${1:-}"
+
+    # XDG Base Directory paths
+    XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
+    XDG_DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}"
+
+    # 環境変数で既に設定されていればそれを使用
+    if [[ -n "${IGNITE_CONFIG_DIR:-}" ]]; then
+        IGNITE_INSTALLED_MODE=false
+        return 0
+    fi
+
+    # インストールモード判定
+    if [[ -f "$XDG_CONFIG_HOME/ignite/.install_paths" ]]; then
+        # インストールモード: XDGパスを使用
+        IGNITE_CONFIG_DIR="$XDG_CONFIG_HOME/ignite"
+        IGNITE_DATA_DIR="$XDG_DATA_HOME/ignite"
+        IGNITE_INSTALLED_MODE=true
+    elif [[ -n "$project_root" ]]; then
+        # 開発モード: PROJECT_ROOTを使用
+        IGNITE_CONFIG_DIR="$project_root/config"
+        IGNITE_DATA_DIR="$project_root"
+        IGNITE_INSTALLED_MODE=false
+    else
+        # フォールバック: スクリプトの場所から推測
+        local script_dir
+        script_dir="$(cd "$(dirname "${BASH_SOURCE[1]:-${BASH_SOURCE[0]}}")" && pwd)"
+        local guessed_root
+        guessed_root="$(cd "$script_dir/../.." 2>/dev/null && pwd)" || guessed_root="$script_dir"
+        IGNITE_CONFIG_DIR="$guessed_root/config"
+        IGNITE_DATA_DIR="$guessed_root"
+        IGNITE_INSTALLED_MODE=false
+    fi
+
+    export IGNITE_CONFIG_DIR
+    export IGNITE_DATA_DIR
+    export IGNITE_INSTALLED_MODE
+}
+
+# =============================================================================
+# ユーティリティ関数
+# =============================================================================
+
+# 移植性のある sed -i 実装 (GNU sed / BSD sed 両対応)
+# 使用方法: sed_inplace 'pattern' file
+sed_inplace() {
+    local pattern="$1"
+    local file="$2"
+    local tmp
+    tmp=$(mktemp)
+    if sed "$pattern" "$file" > "$tmp" && [[ -s "$tmp" || ! -s "$file" ]]; then
+        mv "$tmp" "$file"
+    else
+        rm -f "$tmp"
+        return 1
+    fi
+}
+
+# 移植性のある date 減算 (GNU date / BSD date 両対応)
+# 使用方法: date_subtract "24 hours" または date_subtract "3 minutes"
+date_subtract() {
+    local amount="$1"
+    local value="${amount%% *}"
+    local unit="${amount#* }"
+
+    if date --version &>/dev/null 2>&1; then
+        # GNU date
+        date -d "$amount ago" -Iseconds 2>/dev/null
+    else
+        # BSD date (macOS)
+        local flag
+        case "$unit" in
+            hour|hours) flag="-v-${value}H" ;;
+            minute|minutes) flag="-v-${value}M" ;;
+            day|days) flag="-v-${value}d" ;;
+            *) return 1 ;;
+        esac
+        date "$flag" -Iseconds 2>/dev/null
+    fi
+}
+
+# =============================================================================
+# 初期化
+# =============================================================================
+
+# このファイルが source された時に自動的にパス解決を試みる
+# ただし、既に IGNITE_CONFIG_DIR が設定されている場合はスキップ
+if [[ -z "${IGNITE_COMMON_LOADED:-}" ]]; then
+    IGNITE_COMMON_LOADED=true
+    # パス解決は明示的に呼び出す必要がある場合はコメントアウト
+    # resolve_ignite_paths
+fi


### PR DESCRIPTION
## Summary

- 共通モジュール `scripts/utils/common.sh` を追加
- エージェント起動の待機時間を設定可能に

## Closes

- Closes #59 (XDGパス解決ロジックを共通モジュールに切り出す)
- Closes #60 (カラー定義とログ関数を共通モジュールに切り出す)
- Closes #79 (エージェント起動の待機時間を設定可能にする)

## Changes

### `scripts/utils/common.sh` (新規)

共通機能を提供するモジュール:

| 機能 | 説明 |
|------|------|
| カラー定義 | GREEN, BLUE, YELLOW, RED, CYAN, BOLD, NC |
| ログ関数 | log_info, log_success, log_warn, log_error |
| print関数 | print_info, print_success, print_warning, print_error |
| XDGパス解決 | resolve_ignite_paths() |
| ユーティリティ | sed_inplace(), date_subtract() |

ターミナルのカラーサポートを自動検出し、非対話モードでは無効化。

### `config/system.yaml`

```yaml
claude_code:
  delays:
    startup: 3        # Claude CLI 起動後の待機
    permission: 0.5   # 権限チェック時の待機
    init: 8           # Claude Code 初期化完了までの待機
    prompt: 2         # プロンプト送信後の安定化待機
```

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)