### PR TITLE
feat: ログローテーション機能を実装

### DIFF
--- a/scripts/ignite
+++ b/scripts/ignite
@@ -64,6 +64,57 @@ CYAN='\033[0;36m'
 BOLD='\033[1m'
 NC='\033[0m'
 
+# ログローテーション設定
+LOG_ROTATION_SIZE="${LOG_ROTATION_SIZE:-10485760}"  # 10MB
+LOG_ROTATION_KEEP="${LOG_ROTATION_KEEP:-5}"         # 5世代保持
+
+# =============================================================================
+# ログローテーション関数
+# =============================================================================
+
+# ログファイルをローテーションする
+# 使用方法: rotate_log /path/to/file.log
+rotate_log() {
+    local log_file="$1"
+    local max_size="${2:-$LOG_ROTATION_SIZE}"
+    local keep="${3:-$LOG_ROTATION_KEEP}"
+
+    [[ ! -f "$log_file" ]] && return 0
+
+    # ファイルサイズを取得 (Linux/macOS両対応)
+    local size
+    size=$(stat -f%z "$log_file" 2>/dev/null || stat -c%s "$log_file" 2>/dev/null || echo 0)
+
+    if [[ "$size" -gt "$max_size" ]]; then
+        # タイムスタンプ付きでローテーション
+        local timestamp
+        timestamp=$(date +%Y%m%d%H%M%S)
+        mv "$log_file" "${log_file}.${timestamp}"
+
+        # 古いログを削除（keep世代以上は削除）
+        local count=0
+        # shellcheck disable=SC2012
+        for old_log in $(ls -t "${log_file}".* 2>/dev/null); do
+            count=$((count + 1))
+            if [[ $count -gt $keep ]]; then
+                rm -f "$old_log"
+            fi
+        done
+        return 0
+    fi
+    return 1
+}
+
+# 全ログファイルをローテーションする
+rotate_all_logs() {
+    local log_dir="${1:-$WORKSPACE_DIR/logs}"
+    [[ ! -d "$log_dir" ]] && return 0
+
+    for log_file in "$log_dir"/*.log; do
+        [[ -f "$log_file" ]] && rotate_log "$log_file"
+    done
+}
+
 # =============================================================================
 # セッションID・ワークスペース管理
 # =============================================================================
@@ -380,6 +431,8 @@ cmd_start() {
     mkdir -p "$WORKSPACE_DIR/reports"
     mkdir -p "$WORKSPACE_DIR/context"
     mkdir -p "$WORKSPACE_DIR/logs"
+    # 起動時にログローテーションを実行
+    rotate_all_logs "$WORKSPACE_DIR/logs"
     mkdir -p "$WORKSPACE_DIR/state"  # Watcher用ステートファイル保存先
     mkdir -p "$WORKSPACE_DIR/repos"  # 外部リポジトリのclone先
 


### PR DESCRIPTION
## Summary

`system.yaml` に定義されていた `log_rotation_size` の実装を追加

## Closes

- Closes #70 (ログローテーション機能を実装する)
- Note: #78 (ignite logsコマンド) は既に実装済みでした

## Changes

### ログローテーション関数

| 関数 | 説明 |
|------|------|
| `rotate_log` | 単一ログファイルをローテーション |
| `rotate_all_logs` | ディレクトリ内の全ログを一括ローテーション |

### 機能

- 指定サイズを超えたログファイルを自動ローテーション
- タイムスタンプ付きでバックアップ（例: `file.log.20260204120000`）
- 古いログの自動削除（デフォルト5世代保持）
- Linux/macOS両対応（stat コマンドの差異を吸収）
- 起動時（`ignite start`）に自動実行

### 設定

環境変数で設定可能:

```bash
LOG_ROTATION_SIZE=10485760  # 10MB（デフォルト）
LOG_ROTATION_KEEP=5         # 5世代（デフォルト）
```

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)