### PR TITLE
fix: log出力関数を標準エラー出力に変更してBot Token混入を防止

### DIFF
--- a/scripts/utils/comment_on_issue.sh
+++ b/scripts/utils/comment_on_issue.sh
@@ -35,9 +35,9 @@ YELLOW='\033[1;33m'
 RED='\033[0;31m'
 NC='\033[0m'
 
-# ログ出力
-log_info() { echo -e "${BLUE}[INFO]${NC} $1"; }
-log_success() { echo -e "${GREEN}[OK]${NC} $1"; }
+# ログ出力（すべて標準エラー出力に出力して、コマンド置換で混入しないようにする）
+log_info() { echo -e "${BLUE}[INFO]${NC} $1" >&2; }
+log_success() { echo -e "${GREEN}[OK]${NC} $1" >&2; }
 log_warn() { echo -e "${YELLOW}[WARN]${NC} $1" >&2; }
 log_error() { echo -e "${RED}[ERROR]${NC} $1" >&2; }
 

--- a/scripts/utils/create_pr.sh
+++ b/scripts/utils/create_pr.sh
@@ -36,10 +36,10 @@ YELLOW='\033[1;33m'
 RED='\033[0;31m'
 NC='\033[0m'
 
-# ログ出力
-log_info() { echo -e "${BLUE}[INFO]${NC} $1"; }
-log_success() { echo -e "${GREEN}[OK]${NC} $1"; }
-log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+# ログ出力（すべて標準エラー出力に出力して、コマンド置換で混入しないようにする）
+log_info() { echo -e "${BLUE}[INFO]${NC} $1" >&2; }
+log_success() { echo -e "${GREEN}[OK]${NC} $1" >&2; }
+log_warn() { echo -e "${YELLOW}[WARN]${NC} $1" >&2; }
 log_error() { echo -e "${RED}[ERROR]${NC} $1" >&2; }
 
 # =============================================================================

--- a/scripts/utils/github_watcher.sh
+++ b/scripts/utils/github_watcher.sh
@@ -40,12 +40,12 @@ RED='\033[0;31m'
 CYAN='\033[0;36m'
 NC='\033[0m'
 
-# ログ出力
-log_info() { echo -e "[$(date '+%Y-%m-%d %H:%M:%S')] ${BLUE}[INFO]${NC} $1"; }
-log_success() { echo -e "[$(date '+%Y-%m-%d %H:%M:%S')] ${GREEN}[OK]${NC} $1"; }
-log_warn() { echo -e "[$(date '+%Y-%m-%d %H:%M:%S')] ${YELLOW}[WARN]${NC} $1"; }
-log_error() { echo -e "[$(date '+%Y-%m-%d %H:%M:%S')] ${RED}[ERROR]${NC} $1"; }
-log_event() { echo -e "[$(date '+%Y-%m-%d %H:%M:%S')] ${CYAN}[EVENT]${NC} $1"; }
+# ログ出力（すべて標準エラー出力に出力して、コマンド置換で混入しないようにする）
+log_info() { echo -e "[$(date '+%Y-%m-%d %H:%M:%S')] ${BLUE}[INFO]${NC} $1" >&2; }
+log_success() { echo -e "[$(date '+%Y-%m-%d %H:%M:%S')] ${GREEN}[OK]${NC} $1" >&2; }
+log_warn() { echo -e "[$(date '+%Y-%m-%d %H:%M:%S')] ${YELLOW}[WARN]${NC} $1" >&2; }
+log_error() { echo -e "[$(date '+%Y-%m-%d %H:%M:%S')] ${RED}[ERROR]${NC} $1" >&2; }
+log_event() { echo -e "[$(date '+%Y-%m-%d %H:%M:%S')] ${CYAN}[EVENT]${NC} $1" >&2; }
 
 # =============================================================================
 # 設定読み込み

--- a/scripts/utils/queue_monitor.sh
+++ b/scripts/utils/queue_monitor.sh
@@ -14,10 +14,11 @@ YELLOW='\033[1;33m'
 RED='\033[0;31m'
 NC='\033[0m'
 
-log_info() { echo -e "[$(date '+%Y-%m-%d %H:%M:%S')] ${BLUE}[QUEUE]${NC} $1"; }
-log_success() { echo -e "[$(date '+%Y-%m-%d %H:%M:%S')] ${GREEN}[QUEUE]${NC} $1"; }
-log_warn() { echo -e "[$(date '+%Y-%m-%d %H:%M:%S')] ${YELLOW}[QUEUE]${NC} $1"; }
-log_error() { echo -e "[$(date '+%Y-%m-%d %H:%M:%S')] ${RED}[QUEUE]${NC} $1"; }
+# ログ出力（すべて標準エラー出力に出力して、コマンド置換で混入しないようにする）
+log_info() { echo -e "[$(date '+%Y-%m-%d %H:%M:%S')] ${BLUE}[QUEUE]${NC} $1" >&2; }
+log_success() { echo -e "[$(date '+%Y-%m-%d %H:%M:%S')] ${GREEN}[QUEUE]${NC} $1" >&2; }
+log_warn() { echo -e "[$(date '+%Y-%m-%d %H:%M:%S')] ${YELLOW}[QUEUE]${NC} $1" >&2; }
+log_error() { echo -e "[$(date '+%Y-%m-%d %H:%M:%S')] ${RED}[QUEUE]${NC} $1" >&2; }
 
 # 設定
 WORKSPACE_DIR="${WORKSPACE_DIR:-$PROJECT_ROOT/workspace}"

--- a/scripts/utils/setup_repo.sh
+++ b/scripts/utils/setup_repo.sh
@@ -22,10 +22,10 @@ YELLOW='\033[1;33m'
 RED='\033[0;31m'
 NC='\033[0m'
 
-# ログ出力
-log_info() { echo -e "${BLUE}[INFO]${NC} $1"; }
-log_success() { echo -e "${GREEN}[OK]${NC} $1"; }
-log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+# ログ出力（すべて標準エラー出力に出力して、コマンド置換で混入しないようにする）
+log_info() { echo -e "${BLUE}[INFO]${NC} $1" >&2; }
+log_success() { echo -e "${GREEN}[OK]${NC} $1" >&2; }
+log_warn() { echo -e "${YELLOW}[WARN]${NC} $1" >&2; }
 log_error() { echo -e "${RED}[ERROR]${NC} $1" >&2; }
 
 # =============================================================================

--- a/scripts/utils/update_pr.sh
+++ b/scripts/utils/update_pr.sh
@@ -24,10 +24,10 @@ YELLOW='\033[1;33m'
 RED='\033[0;31m'
 NC='\033[0m'
 
-# ログ出力
-log_info() { echo -e "${BLUE}[INFO]${NC} $1"; }
-log_success() { echo -e "${GREEN}[OK]${NC} $1"; }
-log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+# ログ出力（すべて標準エラー出力に出力して、コマンド置換で混入しないようにする）
+log_info() { echo -e "${BLUE}[INFO]${NC} $1" >&2; }
+log_success() { echo -e "${GREEN}[OK]${NC} $1" >&2; }
+log_warn() { echo -e "${YELLOW}[WARN]${NC} $1" >&2; }
 log_error() { echo -e "${RED}[ERROR]${NC} $1" >&2; }
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- ログ出力関数(`log_info`, `log_success`等)を標準エラー出力(`>&2`)に変更
- 6つのユーティリティスクリプトすべてで修正を適用
- `get_cached_bot_token`関数内のログがGH_TOKENに混入する問題を解消

## 原因と修正
`log_info`などのログ出力関数が標準出力に出力していたため、コマンド置換`$()`でトークンと一緒にキャプチャされていました。

```bash
# 修正前 - ログがstdoutに混入
bot_token=$(get_bot_token "$repo")
# 結果: bot_token='[INFO] キャッシュから...\nghs_XXXX'

# 修正後 - ログはstderrへ
bot_token=$(get_bot_token "$repo")
# 結果: bot_token='ghs_XXXX'
```

## 修正ファイル
- `scripts/utils/comment_on_issue.sh`
- `scripts/utils/create_pr.sh`
- `scripts/utils/github_watcher.sh`
- `scripts/utils/queue_monitor.sh`
- `scripts/utils/setup_repo.sh`
- `scripts/utils/update_pr.sh`

## Test plan
- [ ] `comment_on_issue.sh --bot` でBot名義コメント投稿が成功することを確認
- [ ] ログ出力がターミナルに表示されることを確認

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)