### PR TITLE
fix: resolve issue #104

### DIFF
--- a/instructions/leader.md
+++ b/instructions/leader.md
@@ -118,6 +118,7 @@ claude codeのビルトインツールを使用できます:
      - `progress_update`: Coordinatorからの進捗報告
      - `github_event`: GitHub Watcherからのイベント通知（Issue/PR/コメント）
      - `github_task`: GitHub Watcherからのタスクリクエスト（メンショントリガー）
+     - `system_init`: システム起動時の初期化メッセージ。初期化完了を確認し、メッセージファイルを削除する（ダッシュボード初期化はLeader起動時に実施済みのため二重初期化は行わない）
    - 処理完了したメッセージファイルは削除（Bashツールで `rm`）
 
 3. **意思決定と指示**

--- a/scripts/ignite
+++ b/scripts/ignite
@@ -458,7 +458,7 @@ priority: high
 payload:
   message: "システムが起動しました。初期化を完了してください。"
   action: "initialize_dashboard"
-status: processing
+status: queued
 EOF
 
     echo ""


### PR DESCRIPTION
Closes #104

## Summary
- `scripts/ignite`: system_initメッセージ生成時の `status: processing` を `status: queued` に修正
- `instructions/leader.md`: メッセージ処理タイプリストに `system_init` を追加（初期化確認受領 + ファイル削除）

## Root Cause
system_initメッセージが `status: processing` で生成されていたため、queue_monitor（`status: queued` のみ検知）が検出できず、Leaderに通知されないままqueueに残り続けていた。

## Changes
1. **scripts/ignite (1行変更)**: `status: processing` → `status: queued`
2. **instructions/leader.md (1箇所追加)**: system_initメッセージの処理ルールを追加

## Test Plan
- [ ] システム起動時に `system_init_*.yaml` が `status: queued` で生成されることを確認
- [ ] queue_monitorが `system_init` メッセージを検知しLeaderに通知することを確認
- [ ] Leaderが `system_init` タイプを認識し処理後にファイルを削除することを確認
- [ ] `queue/leader/` にsystem_init_*.yamlが残らないことを確認

---
*Generated by IGNITE AI Team*