### PR TITLE
fix: resolve issue #106

### DIFF
--- a/scripts/utils/create_pr.sh
+++ b/scripts/utils/create_pr.sh
@@ -132,6 +132,12 @@ create_branch() {
     # 既存のブランチがあるか確認
     if git show-ref --verify --quiet "refs/heads/${branch_name}"; then
         log_warn "ブランチが既に存在します: $branch_name"
+        if [[ ! -t 0 ]]; then
+            # 非対話環境: 既存ブランチに自動切り替え
+            log_info "非対話環境のため、既存ブランチに自動切り替えします"
+            git checkout "$branch_name"
+            return 0
+        fi
         read -p "既存のブランチに切り替えますか? (Y/n): " -n 1 -r
         echo
         if [[ ! $REPLY =~ ^[Nn]$ ]]; then


### PR DESCRIPTION
Closes #106

## Summary
- `scripts/utils/create_pr.sh` の `create_branch()` 関数に非対話環境検知を追加
- `-t 0` でstdinがターミナルかを判定し、非対話環境では既存ブランチに自動切り替え
- 対話環境では従来の `read -p` による確認動作を維持

## Root Cause
`create_branch()` 関数が既存ブランチを検出した際に `read -p` で対話入力を要求するため、IGNITEシステムの非対話環境（tmux経由の自動実行）でスクリプトが失敗していた。

## Changes
- **scripts/utils/create_pr.sh (+6行)**: `create_branch()` 関数に `-t 0` チェックを追加

## Test Plan
- [ ] 非対話環境 + 既存ブランチあり → 自動切り替えされ後続処理に進むこと
- [ ] 対話環境 + 既存ブランチあり + Y入力 → 既存ブランチに切り替え
- [ ] 対話環境 + 既存ブランチあり + N入力 → キャンセルされ exit 1
- [ ] ブランチが存在しない → 新規ブランチが作成される（既存動作のまま）

---
*Generated by IGNITE AI Team*