### PR TITLE
feat: display IGNITE version across UI surfaces

### DIFF
--- a/scripts/lib/cmd_help.sh
+++ b/scripts/lib/cmd_help.sh
@@ -253,6 +253,7 @@ cmd_help() {
             ;;
         "")
             echo -e "${BOLD}IGNITE${NC} - Intelligent Generative Networked Interaction-driven Task Engine"
+            echo -e "IGNITEバージョン: v$VERSION"
             echo ""
             echo "使用方法: ./scripts/ignite <command> [options] [arguments]"
             echo ""

--- a/scripts/lib/cmd_start.sh
+++ b/scripts/lib/cmd_start.sh
@@ -86,6 +86,7 @@ cmd_start() {
 
     print_header "IGNITE システム起動"
     echo ""
+    echo -e "${BLUE}IGNITEバージョン:${NC} v$VERSION"
     echo -e "${BLUE}セッションID:${NC} $SESSION_NAME"
     echo -e "${BLUE}ワークスペース:${NC} $WORKSPACE_DIR"
     echo -e "${BLUE}起動モード:${NC} $agent_mode"
@@ -134,6 +135,7 @@ cmd_start() {
     cat > "$WORKSPACE_DIR/dashboard.md" <<EOF
 # IGNITE Dashboard
 
+IGNITEバージョン: v$VERSION
 更新日時: $(date '+%Y-%m-%d %H:%M:%S')
 
 ## システム状態

--- a/scripts/lib/cmd_status.sh
+++ b/scripts/lib/cmd_status.sh
@@ -33,6 +33,7 @@ cmd_status() {
 
     print_header "IGNITE システム状態"
     echo ""
+    echo -e "${BLUE}IGNITEバージョン:${NC} v$VERSION"
     echo -e "${BLUE}セッション:${NC} $SESSION_NAME"
     echo -e "${BLUE}ワークスペース:${NC} $WORKSPACE_DIR"
     echo ""

--- a/scripts/utils/daily_report.sh
+++ b/scripts/utils/daily_report.sh
@@ -19,6 +19,9 @@ set -u
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
+# バージョン取得（core.sh から）
+IGNITE_VERSION=$(grep -oP '^VERSION="\K[^"]+' "$SCRIPT_DIR/../lib/core.sh" 2>/dev/null || echo "unknown")
+
 # =============================================================================
 # XDG パス解決（インストールモード vs 開発モード）
 # =============================================================================
@@ -353,6 +356,7 @@ generate_initial_body() {
     cat <<EOF
 # IGNITE Daily Report
 
+**IGNITE Version:** v$IGNITE_VERSION
 **Repository:** \`$repo\`
 **Date:** $date
 


### PR DESCRIPTION
## Summary
- 起動画面・ステータス画面・ヘルプ画面・初期ダッシュボードに `IGNITEバージョン: v$VERSION` を表示
- デイリーレポートIssue本文に `**IGNITE Version:** v$IGNITE_VERSION` を表示
- 既存の `$VERSION` 変数（`core.sh`）を利用。新関数・新変数の追加は `daily_report.sh` の `IGNITE_VERSION` のみ

## Changed files (4 files, 5 locations)
- `scripts/lib/cmd_start.sh` — 起動画面 + 初期ダッシュボード
- `scripts/lib/cmd_status.sh` — ステータス画面
- `scripts/lib/cmd_help.sh` — ヘルプ画面
- `scripts/utils/daily_report.sh` — デイリーレポートIssue本文

## Test plan
- [ ] `./scripts/ignite help` でバージョン行が表示されること
- [ ] `./scripts/ignite start` で起動画面にバージョン行が表示されること
- [ ] `./scripts/ignite status` でステータス画面にバージョン行が表示されること
- [ ] `workspace/dashboard.md` にバージョンが記載されていること
- [ ] `daily_report.sh ensure` で作成されるIssue本文にバージョンが含まれること

🤖 Generated with [Claude Code](https://claude.com/claude-code)