### PR TITLE
feat: 複数ワークスペースの同時管理をサポートする (#89)

### DIFF
--- a/scripts/lib/cmd_start.sh
+++ b/scripts/lib/cmd_start.sh
@@ -308,6 +308,9 @@ EOF
 session_name: "${SESSION_NAME}"
 workspace_dir: "${WORKSPACE_DIR}"
 started_at: "$(date -Iseconds)"
+mode: "${agent_mode}"
+agents_total: $((1 + ${#SUB_LEADERS[@]} + worker_count))
+agents_actual: $((1 + ${#SUB_LEADERS[@]} + actual_ignitian_count))
 EOF
 
     # コスト追跡用のセッションID記録


### PR DESCRIPTION
## Summary
- セッション情報YAMLに `mode`, `agents_total`, `agents_actual` フィールドを追加
- `cmd_list()` をテーブル形式表示に拡張（SESSION/STATUS/AGENTS/WORKSPACE）
- tmuxフォールバック・後方互換対応・エッジケース処理を実装

## Changes
### scripts/lib/cmd_start.sh
- セッション情報YAML出力に3フィールド追加: `mode`(起動モード), `agents_total`(目標エージェント数), `agents_actual`(実起動数)

### scripts/lib/commands.sh
- `cmd_list()` をprintfベースのテーブル表示に書き換え
- sessions/*.yaml走査 + tmuxフォールバック（YAMLなしセッション補完）
- glob空結果保護、YAML破損時フォールバック値、tmux未起動時安全処理

## Test plan
- [ ] `ignite start` で新フィールド含むYAMLが生成されることを確認
- [ ] `ignite list` でテーブル形式の一覧が表示されることを確認
- [ ] 複数セッション同時起動でテーブルに全件表示されることを確認
- [ ] tmux未起動時にエラーなく動作することを確認
- [ ] 古いフォーマットのYAMLでもフォールバック値で表示されることを確認

Closes #89

🤖 Generated with [IGNITE](https://github.com/myfinder/IGNITE)