### PR TITLE
feat: require repository field in progress_update/evaluation_result

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -281,6 +281,7 @@ to: leader
 timestamp: "2026-01-31T17:18:00+09:00"
 priority: high
 payload:
+  repository: "owner/repo"
   task_id: "task_001"
   title: "タスク名"
   overall_status: "pass"  # pass, pass_with_notes, fail
@@ -371,6 +372,7 @@ to: leader
 timestamp: "2026-01-31T17:10:00+09:00"
 priority: normal
 payload:
+  repository: "owner/repo"
   total_tasks: 3
   completed: 1
   in_progress: 2

--- a/instructions/coordinator.md
+++ b/instructions/coordinator.md
@@ -128,6 +128,7 @@ to: leader
 timestamp: "2026-01-31T17:10:00+09:00"
 priority: normal
 payload:
+  repository: "owner/repo"
   total_tasks: 3
   completed: 1
   in_progress: 2
@@ -580,6 +581,7 @@ type: evaluation_result
 from: evaluator
 to: coordinator  # または leader（直接送信の場合）
 payload:
+  repository: "owner/repo"
   task_id: "task_001"
   verdict: "approve"       # approve / revise / reject
   summary: "全必須セクションが存在し、Markdown構文も問題なし"

--- a/instructions/evaluator.md
+++ b/instructions/evaluator.md
@@ -112,6 +112,7 @@ to: leader
 timestamp: "2026-01-31T17:18:00+09:00"
 priority: high
 payload:
+  repository: "owner/repo"
   task_id: "task_001"
   title: "README骨組み作成"
 

--- a/instructions/leader.md
+++ b/instructions/leader.md
@@ -144,6 +144,7 @@ to: leader
 timestamp: "2026-01-31T17:18:00+09:00"
 priority: high
 payload:
+  repository: "owner/repo"
   task_id: "task_001"
   title: "README骨組み作成"
 

--- a/scripts/utils/queue_monitor.sh
+++ b/scripts/utils/queue_monitor.sh
@@ -188,14 +188,11 @@ _report_progress() {
     local today
     today=$(date +%Y-%m-%d)
 
-    # repository があればそれだけ、なければ全件（後方互換）
-    local repos
-    if [[ -n "$msg_repo" ]]; then
-        repos="$msg_repo"
-    else
-        repos=$(jq -r --arg date "$today" 'to_entries[] | select(.value[$date] != null) | .key' "$cache_file" 2>/dev/null)
+    # repository 必須: なければ投稿スキップ
+    if [[ -z "$msg_repo" ]]; then
+        return 0
     fi
-    [[ -n "$repos" ]] || return 0
+    local repos="$msg_repo"
 
     local comment_body
     comment_body="### Progress Update
@@ -246,14 +243,11 @@ _report_evaluation() {
     local today
     today=$(date +%Y-%m-%d)
 
-    # repository があればそれだけ、なければ全件（後方互換）
-    local repos
-    if [[ -n "$msg_repo" ]]; then
-        repos="$msg_repo"
-    else
-        repos=$(jq -r --arg date "$today" 'to_entries[] | select(.value[$date] != null) | .key' "$cache_file" 2>/dev/null)
+    # repository 必須: なければ投稿スキップ
+    if [[ -z "$msg_repo" ]]; then
+        return 0
     fi
-    [[ -n "$repos" ]] || return 0
+    local repos="$msg_repo"
 
     local verdict_emoji
     case "$verdict" in


### PR DESCRIPTION
## Summary

- `progress_update` / `evaluation_result` メッセージで `repository` フィールドがない場合、全リポジトリへのフォールバック投稿を廃止し、投稿をスキップする動作に変更
- 全 instructions (`coordinator.md`, `evaluator.md`, `leader.md`) と `docs/protocol.md` の YAML 例に `repository` フィールドを追加し、エージェントが常に含めるようガイド

Depends on #155

## Test plan

- [x] `bash -n scripts/utils/queue_monitor.sh` 構文チェック通過
- [x] `repository` あり → 指定リポジトリにのみ投稿されること
- [x] `repository` なし → 投稿がスキップされること (`return 0`)
- [x] 別リポジトリには投稿されないこと
- [x] 全 instructions / docs の YAML 例に `repository` フィールドが含まれていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)