### PR TITLE
ci: add gate job to aggregate test results

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,3 +35,16 @@ jobs:
           scandir: './scripts'
           severity: warning
           format: tty
+
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    needs: [bats-test, shellcheck]
+    if: always()
+    steps:
+      - name: Check results
+        run: |
+          if [[ "${{ needs.bats-test.result }}" != "success" || "${{ needs.shellcheck.result }}" != "success" ]]; then
+            echo "One or more checks failed"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

- Rulesetの required status check `test` と実際のジョブ名 (`Bats Tests` / `ShellCheck`) が不一致でPRがブロックされていた問題を修正
- 全ジョブの結果を集約するゲートジョブ `test` を追加
- 今後テストジョブを追加しても Ruleset の変更は不要

## Test plan

- [ ] PR上で `test` チェックが表示され、`Bats Tests` / `ShellCheck` の両方がpassした後に `test` もpassすること
- [ ] マージブロックが解消されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)