### PR TITLE
fix: daily report current tasks section not updating due to awk format mismatch

### DIFF
--- a/scripts/utils/queue_monitor.sh
+++ b/scripts/utils/queue_monitor.sh
@@ -336,16 +336,16 @@ _generate_repo_report() {
 
     [[ -f "$dashboard" ]] || return 0
 
-    # 「現在のタスク」セクションからこのrepoのエントリだけ抽出
-    # 各タスクは "- " で始まり、インデントされた子行（"  - ブランチ:" 等）が続く
+    # NOTE: 現在のタスクセクションはテーブル形式/リスト形式いずれも許容
+    # _sync_dashboard_to_reports() から ~5分ごとに呼ばれる
+    # TODO: dashboard.md の presentation/data-source 二重責務の分離
+    # TODO: tasks テーブルへの登録パイプライン整備
+    # TODO: 複数リポジトリ運用時の repo 別フィルタリング機構
     local task_lines
-    task_lines=$(awk -v repo="$repo" '
+    task_lines=$(awk '
         /^## 現在のタスク/ { in_section=1; next }
-        /^## / { in_section=0 }
-        in_section && /^- / {
-            if (index($0, "(" repo ")") > 0) { show=1 } else { show=0 }
-        }
-        in_section && show { print }
+        /^## /             { in_section=0 }
+        in_section         { print }
     ' "$dashboard")
 
     # body 組み立て


### PR DESCRIPTION
## Summary

Daily Report の「現在のタスク」セクションが常に空になるバグを修正しました。

Closes #174

## Root Cause（根本原因 - 2層）

### Layer 1: awk フォーマット不一致
`_generate_repo_report()` 内の awk が `/^- /`（リスト形式）を前提としていたが、`dashboard.md` はテーブル形式（`| Issue | ...`）で出力されており、パターンが一切マッチせず常に空を返していた。

### Layer 2: repo フィルタ列の不在
awk が `index($0, "(" repo ")")` で repo 名フィルタをしていたが、テーブル形式にも SQLite の tasks テーブルにも repo 列が存在しないため、フィルタ自体が機能しない構造だった。

## Changes（修正内容）

| 変更 | 詳細 |
|------|------|
| **awk 簡素化** | 7行 → 4行。`## 現在のタスク` セクション全体を抽出する方式に変更 |
| **repo フィルタ廃止** | 現状テーブル/SQLite に repo 列がなく機能しないため削除 |
| **NOTE コメント追加** | テーブル/リスト両形式を許容する方針を明記 |
| **TODO 追加** | 将来の改善点3つを記載（二重責務分離、パイプライン整備、repo別フィルタ） |

## Before / After

### Before（修正前の awk でdashboard.mdを処理）
```
=== Before証拠: 修正前awk（リスト形式マッチ版） ===
[RESULT] Current Tasks: 空（出力なし） → バグ再現確認
```

### After（修正後の awk でdashboard.mdを処理）
```
=== After証拠: 修正後awk（セクション全体抽出版） ===
[RESULT] Current Tasks:
| Issue | タイトル | 状態 | ブランチ |
|-------|---------|------|---------|
| #174 | Daily Reportの現在のタスクが更新されない | ⏳ 実行中 (2/3完了) | ignite/issue-174 |
...
```

### 空タスクケース
```
[RESULT]: タスクなし - 新しい目標をお待ちしています
[OK] 空タスクケースで正しくテキストが抽出される
```

## Test plan

- [x] Before証拠: 修正前awk で Current Tasks が空であることを確認
- [x] After証拠: 修正後awk で Current Tasks にタスクが表示されることを確認
- [x] 空タスクケース: タスクなしテキストが正しく抽出される
- [x] `bash -n queue_monitor.sh` 構文チェック PASS
- [ ] CI 全 PASS