### PR TITLE
fix: bot token refresh + config dir fallback (#250)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -44,7 +44,7 @@ print_header() { echo -e "${BOLD}=== $1 ===${NC}"; }
 # =============================================================================
 
 BIN_DIR="${IGNITE_BIN_DIR:-${XDG_BIN_HOME:-$HOME/.local/bin}}"
-CONFIG_DIR="${IGNITE_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/ignite}"
+CONFIG_DIR="${IGNITE_CONFIG_DIR:-$HOME/.ignite}"
 DATA_DIR="${IGNITE_DATA_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/ignite}"
 
 # インストールモードフラグ
@@ -64,7 +64,7 @@ IGNITE インストーラー v${VERSION}
 
 オプション:
   --bin-dir <path>     実行ファイルのインストール先 (デフォルト: ~/.local/bin)
-  --config-dir <path>  設定ファイルのインストール先 (デフォルト: ~/.config/ignite)
+  --config-dir <path>  設定ファイルのインストール先 (デフォルト: ~/.ignite)
   --data-dir <path>    データファイルのインストール先 (デフォルト: ~/.local/share/ignite)
   --upgrade            アップグレードモード (バイナリ・データは上書き、設定は保持)
   --force              既存ファイルをすべて上書き

--- a/scripts/lib/core.sh
+++ b/scripts/lib/core.sh
@@ -10,8 +10,17 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 # パス解決（PROJECT_ROOT ベース）
 # =============================================================================
 
-# 設定テンプレートディレクトリ（ignite init のコピー元）
-IGNITE_CONFIG_DIR="$PROJECT_ROOT/config"
+# 設定ディレクトリ解決:
+# 1. 環境変数 IGNITE_CONFIG_DIR が設定済みならそのまま使用
+# 2. HOME/.ignite があればそちらを優先
+# 3. フォールバック: PROJECT_ROOT/config（テンプレート）
+if [[ -z "${IGNITE_CONFIG_DIR:-}" ]]; then
+    if [[ -d "${HOME}/.ignite" ]]; then
+        IGNITE_CONFIG_DIR="${HOME}/.ignite"
+    else
+        IGNITE_CONFIG_DIR="$PROJECT_ROOT/config"
+    fi
+fi
 IGNITE_DATA_DIR="$PROJECT_ROOT"
 IGNITE_INSTRUCTIONS_DIR="$PROJECT_ROOT/instructions"
 IGNITE_CHARACTERS_DIR="$PROJECT_ROOT/characters"

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -41,7 +41,7 @@ print_header() { echo -e "${BOLD}=== $1 ===${NC}"; }
 # =============================================================================
 
 BIN_DIR="${IGNITE_BIN_DIR:-${XDG_BIN_HOME:-$HOME/.local/bin}}"
-CONFIG_DIR="${IGNITE_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/ignite}"
+CONFIG_DIR="${IGNITE_CONFIG_DIR:-$HOME/.ignite}"
 DATA_DIR="${IGNITE_DATA_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/ignite}"
 CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/ignite"
 

--- a/scripts/utils/comment_on_issue.sh
+++ b/scripts/utils/comment_on_issue.sh
@@ -185,23 +185,16 @@ post_comment() {
     local use_bot="$4"
 
     if [[ "$use_bot" == "true" ]]; then
-        # リポジトリを渡してトークン取得（Organization対応）
+        # キャッシュ付きBot Token取得（期限切れなら自動更新）
         local bot_token
         bot_token=$(get_bot_token "$repo")
         if [[ -n "$bot_token" ]]; then
             log_info "Bot名義でコメントを投稿中... (REST API)"
-            GH_TOKEN="$bot_token" gh api "/repos/${repo}/issues/${issue_number}/comments" \
-                -f body="$body" --silent
-            return $?
-        fi
-        # フォールバック: ペイン起動時の GH_TOKEN を確認
-        if [[ -n "${GH_TOKEN:-}" && "${GH_TOKEN}" == ghs_* ]]; then
-            log_warn "キャッシュBot Token取得失敗。環境変数GH_TOKENを使用します。"
-            if gh api "/repos/${repo}/issues/${issue_number}/comments" \
+            if GH_TOKEN="$bot_token" gh api "/repos/${repo}/issues/${issue_number}/comments" \
                 -f body="$body" --silent 2>/dev/null; then
                 return 0
             fi
-            log_warn "環境変数GH_TOKENでの投稿失敗（期限切れの可能性）。通常のトークンで投稿します。"
+            log_warn "Bot Tokenでの投稿失敗。通常のトークンで投稿します。"
         else
             log_warn "Bot Token取得失敗。通常のトークンで投稿します。"
         fi

--- a/scripts/utils/create_pr.sh
+++ b/scripts/utils/create_pr.sh
@@ -37,6 +37,9 @@ log_success() { echo -e "${GREEN}[OK]${NC} $1" >&2; }
 log_warn() { echo -e "${YELLOW}[WARN]${NC} $1" >&2; }
 log_error() { echo -e "${RED}[ERROR]${NC} $1" >&2; }
 
+# Bot Token / GitHub API 共通関数の読み込み
+source "${SCRIPT_DIR}/github_helpers.sh"
+
 # =============================================================================
 # ヘルプ
 # =============================================================================
@@ -213,32 +216,12 @@ create_pull_request() {
         draft_flag="--draft"
     fi
 
-    # トークン設定
+    # トークン設定（キャッシュ付きBot Token取得、期限切れなら自動更新）
     local bot_token=""
     if [[ "$use_bot" == "true" ]]; then
-        local _token_err _token_rc=0
-        _token_err=$(mktemp)
-        # IGNITE_CONFIG_DIR が設定されていれば、github-app.yaml のパスを渡す
-        # --repo オプションでリポジトリを指定（Organization対応）
-        if [[ -n "${IGNITE_CONFIG_DIR:-}" ]]; then
-            bot_token=$(IGNITE_GITHUB_CONFIG="${IGNITE_CONFIG_DIR}/github-app.yaml" "${SCRIPT_DIR}/get_github_app_token.sh" --repo "$repo" 2>>"$_token_err") || _token_rc=$?
-        else
-            bot_token=$("${SCRIPT_DIR}/get_github_app_token.sh" --repo "$repo" 2>>"$_token_err") || _token_rc=$?
-        fi
-        if [[ $_token_rc -ne 0 ]]; then
-            log_warn "Bot Token取得失敗 (exit_code=$_token_rc)"
-            [[ -s "$_token_err" ]] && log_warn "$(cat "$_token_err")"
-            bot_token=""
-        fi
-        rm -f "$_token_err"
+        bot_token=$(get_cached_bot_token "$repo") || true
         if [[ -z "$bot_token" ]]; then
-            # フォールバック: ペイン起動時の GH_TOKEN を確認
-            if [[ -n "${GH_TOKEN:-}" && "${GH_TOKEN}" == ghs_* ]]; then
-                log_warn "直接のBot Token取得失敗。環境変数GH_TOKENを使用します。"
-                bot_token="${GH_TOKEN}"
-            else
-                log_warn "Bot Token取得失敗。通常のトークンで作成します。"
-            fi
+            log_warn "Bot Token取得失敗。通常のトークンで作成します。"
         fi
     fi
 

--- a/scripts/utils/github_watcher.sh
+++ b/scripts/utils/github_watcher.sh
@@ -25,6 +25,9 @@ fi
 # YAMLユーティリティ
 source "${SCRIPT_DIR}/../lib/yaml_utils.sh"
 
+# Bot Token / GitHub API 共通関数の読み込み
+source "${SCRIPT_DIR}/github_helpers.sh"
+
 # MIMEメッセージ構築ツール
 IGNITE_MIME="${SCRIPT_DIR}/../lib/ignite_mime.py"
 
@@ -426,43 +429,7 @@ is_user_authorized() {
 # イベント取得
 # =============================================================================
 
-# GitHub Appトークンを取得
-# 引数: $1 - リポジトリ名（owner/repo形式、オプション）
-get_bot_token() {
-    local repo="${1:-}"
-    local token_script="${SCRIPT_DIR}/get_github_app_token.sh"
-    local repo_option=""
-    local _token_rc=0
-    local _token_err
-    local _token_result=""
-
-    # リポジトリが指定されている場合は --repo オプションを使用（Organization対応）
-    if [[ -n "$repo" ]]; then
-        repo_option="--repo $repo"
-    fi
-
-    if [[ -f "$token_script" ]]; then
-        _token_err=$(mktemp)
-        # IGNITE_CONFIG_DIR が設定されていれば、github-app.yaml のパスを渡す
-        if [[ -n "${IGNITE_CONFIG_DIR:-}" ]]; then
-            _token_result=$(IGNITE_GITHUB_CONFIG="${IGNITE_CONFIG_DIR}/github-app.yaml" \
-                "$token_script" $repo_option 2>>"$_token_err") || _token_rc=$?
-        else
-            _token_result=$("$token_script" $repo_option 2>>"$_token_err") || _token_rc=$?
-        fi
-        if [[ $_token_rc -ne 0 ]]; then
-            log_warn "Bot Token取得失敗 (exit_code=$_token_rc)"
-            [[ -s "$_token_err" ]] && log_warn "$(cat "$_token_err")"
-            rm -f "$_token_err"
-            echo ""
-            return
-        fi
-        rm -f "$_token_err"
-        echo "$_token_result"
-    else
-        echo ""
-    fi
-}
+# get_bot_token() は github_helpers.sh から提供（キャッシュ + リトライ機構付き）
 
 # Issueイベントを取得
 fetch_issues() {


### PR DESCRIPTION
Closes #250

## Summary

Fix-2〜Fix-4 を実装。Fix-1（utils/ スクリプトの IGNITE_CONFIG_DIR 独自解決廃止 + core.sh source 追加）は #158 PR（refactor-utils-dedup）で対応するため本PRではスキップ。

### Fix-2: install.sh / uninstall.sh の ~/.config/ignite 参照修正 (Major)
- `CONFIG_DIR` のフォールバックを `~/.config/ignite` → `~/.ignite` に変更
- ヘルプテキストのデフォルトパス表記も更新

### Fix-3: GH_TOKEN 期限切れ時の自動更新 (Major)
- **create_pr.sh**: `github_helpers.sh` を source し、直接の `get_github_app_token.sh` 呼び出しを `get_cached_bot_token()` に置き換え。環境変数 `GH_TOKEN` フォールバック削除
- **github_watcher.sh**: ローカル `get_bot_token()` 関数を削除し、`github_helpers.sh` のキャッシュ+リトライ機構付き版に統一
- **comment_on_issue.sh**: 環境変数 `GH_TOKEN` への直接フォールバック（`ghs_*` チェック）を削除。キャッシュ経由のトークン取得のみに統一
- **update_pr.sh**: Bot Token使用箇所なし（git操作のみ）のため変更不要

### Fix-4: core.sh の IGNITE_CONFIG_DIR 初期値に HOME/.ignite 追加 (Minor)
- line 14 の無条件代入を条件分岐に変更
- 解決順序: 環境変数 IGNITE_CONFIG_DIR → $HOME/.ignite → PROJECT_ROOT/config
- VERSION (0.4.1) は変更なし

## Changes
- `scripts/lib/core.sh`: IGNITE_CONFIG_DIR を条件付き設定に変更（+HOME/.ignite）
- `scripts/install.sh`: CONFIG_DIR フォールバック + ヘルプ修正
- `scripts/uninstall.sh`: CONFIG_DIR フォールバック修正
- `scripts/utils/create_pr.sh`: github_helpers.sh source + get_cached_bot_token 使用
- `scripts/utils/github_watcher.sh`: ローカル get_bot_token 削除 + github_helpers.sh source
- `scripts/utils/comment_on_issue.sh`: GH_TOKEN env フォールバック削除

---
*Generated by IGNITE AI Team*