### PR TITLE
perf: bats テストの並列実行 (#290)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
           loginctl enable-linger "$(whoami)" || true
 
       - name: Run Bats tests
-        run: bats tests/
+        run: bats --jobs "$(($(nproc) * 8))" tests/
 
   shellcheck:
     name: ShellCheck

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,14 +34,15 @@ docs/                 # ドキュメント
 ### テスト
 
 ```bash
-# 全テスト実行
-bats tests/
+# 全テスト実行（並列）
+bats --jobs "$(($(nproc) * 8))" tests/
 
 # 特定テストファイル
 bats tests/test_cmd_start_init.bats
 ```
 
-PR を出す前に必ず `bats tests/` を実行してください。
+PR を出す前に必ず `bats --jobs "$(($(nproc) * 8))" tests/` を実行してください。
+並列実行には GNU parallel が必要です（`apt install parallel` / `brew install parallel`）。
 
 ### 動作確認
 


### PR DESCRIPTION
## Summary
- CI の bats テストを `--jobs "$(($(nproc) * 8))"` で並列実行に変更
- AGENTS.md のテスト実行コマンドを更新
- GNU parallel は CI の ubuntu-latest にプリインストール済み

## 実測結果

| 環境 | 直列 | 並列 | 高速化 |
|---|---|---|---|
| ローカル (20コア) | 1m42s | 16s | **約6倍** |
| CI (4コア) | 約2m | 推定30s前後 | **約4倍** |

bats はファイル単位の並列実行（14ファイル）。テストは `setup_temp_dir` で独立した一時ディレクトリを使用しており、並列実行で3回連続全通過を確認済み。

Closes #290

## Test plan
- [x] ローカル: `bats --jobs "$(($(nproc) * 8))" tests/` 3回連続全166テスト通過
- [x] CI: 全ジョブ成功を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)