### PR TITLE
fix: setup_session_name() の複数ワークスペース対応

### DIFF
--- a/scripts/lib/cmd_stop.sh
+++ b/scripts/lib/cmd_stop.sh
@@ -56,6 +56,8 @@ cmd_stop() {
     fi
 
     # ワークスペース解決: -w 指定 > セッション情報 > デフォルト
+    # NOTE: setup_session_name() が runtime.yaml から解決した場合、
+    # WORKSPACE_DIR は既にセットされているためこのブロックはスキップされる
     if [[ -z "$WORKSPACE_DIR" ]]; then
         local session_info="$IGNITE_CONFIG_DIR/sessions/${SESSION_NAME}.yaml"
         if [[ -f "$session_info" ]]; then

--- a/tests/test_session.bats
+++ b/tests/test_session.bats
@@ -5,10 +5,15 @@ load test_helper
 
 setup() {
     setup_temp_dir
-    # require_workspace が使う print_error / print_info のスタブ
+    # require_workspace / setup_session_name が使うスタブ
     print_error() { echo "[ERROR] $*"; }
     print_info() { echo "[INFO] $*"; }
-    export -f print_error print_info
+    print_warning() { echo "[WARN] $*"; }
+    log_info() { :; }
+    export -f print_error print_info print_warning log_info
+    # yaml_utils.sh を読み込み（yaml_get が必要）
+    unset __LIB_YAML_UTILS_LOADED
+    source "$SCRIPTS_DIR/lib/yaml_utils.sh"
     # session.sh を読み込み（ガード変数をクリア）
     unset __LIB_SESSION_LOADED
     source "$SCRIPTS_DIR/lib/session.sh"
@@ -45,4 +50,111 @@ teardown() {
     run require_workspace
     [ "$status" -eq 1 ]
     [[ "$output" == *"ignite start"* ]]
+}
+
+# --- setup_session_name ---
+
+# tmux モック作成ヘルパー
+# TMUX_MOCK_HAS_SESSION: "success" | "fail" (has-session の戻り値)
+# TMUX_MOCK_LIST_SESSIONS: 改行区切りのセッション名リスト
+_create_tmux_mock() {
+    local mock_dir="$TEST_TEMP_DIR/bin"
+    mkdir -p "$mock_dir"
+    cat > "$mock_dir/tmux" << 'MOCK'
+#!/bin/bash
+case "$1" in
+    has-session)
+        if [[ "${TMUX_MOCK_HAS_SESSION:-fail}" == "success" ]]; then
+            exit 0
+        else
+            exit 1
+        fi
+        ;;
+    list-sessions)
+        if [[ -n "${TMUX_MOCK_LIST_SESSIONS:-}" ]]; then
+            echo "$TMUX_MOCK_LIST_SESSIONS"
+        fi
+        exit 0
+        ;;
+    *)
+        exit 1
+        ;;
+esac
+MOCK
+    chmod +x "$mock_dir/tmux"
+    export PATH="$mock_dir:$PATH"
+}
+
+@test "setup_session_name: runtime.yaml からセッション名を取得" {
+    # ワークスペースに runtime.yaml を作成
+    local ws="$TEST_TEMP_DIR/workspace"
+    mkdir -p "$ws/.ignite"
+    cat > "$ws/.ignite/runtime.yaml" << EOF
+session_name: ignite-test1234
+dry_run: false
+EOF
+
+    # tmux モック: has-session 成功
+    export TMUX_MOCK_HAS_SESSION="success"
+    _create_tmux_mock
+
+    SESSION_NAME=""
+    WORKSPACE_DIR="$ws"
+
+    setup_session_name
+
+    [ "$SESSION_NAME" = "ignite-test1234" ]
+    [ "$WORKSPACE_DIR" = "$ws" ]
+}
+
+@test "setup_session_name: セッション1つならそのセッションを使用" {
+    # tmux モック: has-session 失敗（runtime.yaml パスをスキップ）、list-sessions は1つ
+    export TMUX_MOCK_HAS_SESSION="fail"
+    export TMUX_MOCK_LIST_SESSIONS="ignite-abcd"
+    _create_tmux_mock
+
+    SESSION_NAME=""
+    WORKSPACE_DIR=""
+
+    setup_session_name
+
+    [ "$SESSION_NAME" = "ignite-abcd" ]
+}
+
+@test "setup_session_name: 複数セッションでエラー終了" {
+    # tmux モック: list-sessions が複数返す
+    export TMUX_MOCK_HAS_SESSION="fail"
+    export TMUX_MOCK_LIST_SESSIONS=$'ignite-aaaa\nignite-bbbb'
+    _create_tmux_mock
+
+    SESSION_NAME=""
+    WORKSPACE_DIR=""
+
+    run setup_session_name
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"複数の IGNITE セッション"* ]]
+}
+
+@test "setup_session_name: runtime.yaml のセッションが存在しない場合フォールバック" {
+    # ワークスペースに runtime.yaml を作成
+    local ws="$TEST_TEMP_DIR/workspace"
+    mkdir -p "$ws/.ignite"
+    cat > "$ws/.ignite/runtime.yaml" << EOF
+session_name: ignite-dead
+dry_run: false
+EOF
+
+    # tmux モック: has-session 失敗、list-sessions は1つ
+    export TMUX_MOCK_HAS_SESSION="fail"
+    export TMUX_MOCK_LIST_SESSIONS="ignite-live"
+    _create_tmux_mock
+
+    SESSION_NAME=""
+    WORKSPACE_DIR="$ws"
+
+    setup_session_name
+
+    # runtime.yaml のセッションは存在しないのでフォールバックして list-sessions の結果を使う
+    [ "$SESSION_NAME" = "ignite-live" ]
 }


### PR DESCRIPTION
## Summary

- 複数ワークスペース同時起動時に `-s` なしの `stop/restart/attach` が `head -1` で最初のセッションを選び、別ワークスペースを誤停止する問題を修正
- `setup_session_name()` を3段階解決ロジック（runtime.yaml → セッション一覧 → 新規生成）に書き換え
- `smoke_test.sh` の cleanup を自セッション限定に変更し、他ワークスペースへの影響を排除

## Changes

| ファイル | 変更内容 |
|---------|---------|
| `scripts/lib/session.sh` | `setup_session_name()` を3段階ロジックに書き換え |
| `scripts/lib/cmd_stop.sh` | runtime.yaml 解決時のコメント追加 |
| `scripts/smoke_test.sh` | cleanup を `SMOKE_SESSION_NAME` 限定に変更 |
| `tests/test_session.bats` | `setup_session_name` のテストケース4件追加 |

## Test plan

- [x] `bats --jobs` 全170テスト通過
- [x] shellcheck 警告なし（既存 info のみ）
- [x] 4ワークスペース同時起動で動作確認:
  - `-s`/`-w` なし + 4セッション → エラー + 全セッション一覧
  - `-w` 指定 → runtime.yaml から正しいセッション解決
  - CWD `.ignite/` 自動検出 → 正しいセッション解決
  - 1つだけ stop → 他は生存
  - 1セッションに減ったら自動検出に復帰

Closes #289

🤖 Generated with [Claude Code](https://claude.com/claude-code)