### PR TITLE
feat: 意図分類・タスク追跡パイプラインの修正

### DIFF
--- a/instructions/ignitian.md
+++ b/instructions/ignitian.md
@@ -52,6 +52,7 @@ payload:
   task_id: "task_001"
   title: "README骨組み作成"
   description: "基本的なMarkdown構造を作成"
+  task_type: "implement"   # implement / analyze / document / review / github_ops
   instructions: |
     以下の構造でREADME.mdを作成してください:
     - プロジェクト名: IGNITE
@@ -79,6 +80,14 @@ payload:
 > acceptance_criteria が空配列（`must: [], should: []`）の場合は基準未設定と同義とし、従来通りのセルフレビューで動作します。
 > acceptance_criteria がある場合は、セルフレビュー Round 1 で各項目を必ずチェックし、
 > task_completed に `acceptance_criteria_check` を含めてください。
+
+> **task_type について**: Strategist→Coordinator 経由で伝搬される意図分類。
+> - `implement`: コードファイルの作成/編集が期待される
+> - `analyze`: 分析結果のテキスト出力が期待される
+> - `document`: ドキュメント/説明文の作成が期待される
+> - `review`: レビューコメントの作成が期待される
+> - `github_ops`: GitHub API操作（gh コマンドの実行）が期待される
+> `task_type` がない場合は `instructions` から推測して従来通り動作する（後方互換）。
 
 **送信メッセージ例（完了レポート）:**
 ```yaml

--- a/scripts/schema.sql
+++ b/scripts/schema.sql
@@ -28,6 +28,7 @@ CREATE TABLE IF NOT EXISTS tasks (
     title TEXT,
     repository TEXT,
     issue_number INTEGER,
+    dependencies TEXT,          -- JSON配列: 依存タスクIDリスト ["task_001", "task_002"]
     started_at DATETIME,
     completed_at DATETIME
 );

--- a/tests/fixtures/schema_v3.sql
+++ b/tests/fixtures/schema_v3.sql
@@ -1,0 +1,69 @@
+-- IGNITE メモリデータベース スキーマ v3
+-- アップグレードテスト用 fixture
+-- v4 との差分: tasks.dependencies カラムなし
+PRAGMA user_version = 3;
+
+-- memories テーブル（v3: repository/issue_number あり）
+CREATE TABLE IF NOT EXISTS memories (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    agent TEXT NOT NULL,
+    type TEXT NOT NULL,
+    content TEXT NOT NULL,
+    context TEXT,
+    task_id TEXT,
+    repository TEXT,
+    issue_number INTEGER,
+    timestamp DATETIME DEFAULT (datetime('now', '+9 hours'))
+);
+
+-- tasks テーブル（v3: repository/issue_number あり、dependencies なし）
+CREATE TABLE IF NOT EXISTS tasks (
+    task_id TEXT PRIMARY KEY,
+    assigned_to TEXT NOT NULL,
+    delegated_by TEXT,
+    status TEXT DEFAULT 'queued',
+    title TEXT,
+    repository TEXT,
+    issue_number INTEGER,
+    started_at DATETIME,
+    completed_at DATETIME
+);
+
+-- agent_states テーブル
+CREATE TABLE IF NOT EXISTS agent_states (
+    agent TEXT PRIMARY KEY,
+    status TEXT,
+    current_task_id TEXT,
+    last_active DATETIME,
+    summary TEXT
+);
+
+-- strategist_state テーブル
+CREATE TABLE IF NOT EXISTS strategist_state (
+    request_id TEXT PRIMARY KEY,
+    goal TEXT NOT NULL,
+    status TEXT NOT NULL,
+    created_at DATETIME,
+    draft_strategy TEXT,
+    reviews TEXT
+);
+
+-- insight_log テーブル（v2+ で追加）
+CREATE TABLE IF NOT EXISTS insight_log (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    memory_ids TEXT NOT NULL,
+    repository TEXT NOT NULL,
+    issue_number INTEGER,
+    action TEXT NOT NULL,
+    title TEXT,
+    timestamp DATETIME DEFAULT (datetime('now', '+9 hours'))
+);
+
+-- インデックス
+CREATE INDEX IF NOT EXISTS idx_memories_agent_type ON memories(agent, type, timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_memories_task ON memories(task_id);
+CREATE INDEX IF NOT EXISTS idx_memories_repo_issue ON memories(repository, issue_number, timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_tasks_status ON tasks(status, assigned_to);
+CREATE INDEX IF NOT EXISTS idx_tasks_repo ON tasks(repository, status);
+CREATE INDEX IF NOT EXISTS idx_strategist_status ON strategist_state(status);
+CREATE INDEX IF NOT EXISTS idx_insight_log_repo ON insight_log(repository);

--- a/tests/test_db_init.bats
+++ b/tests/test_db_init.bats
@@ -55,13 +55,13 @@ teardown() {
     [[ "$columns" == *"issue_number"* ]]
 }
 
-@test "新規DB: user_version = 3" {
+@test "新規DB: user_version = 4" {
     init_db_production_sequence "$DB_PATH"
 
     local version
     version=$(get_user_version "$DB_PATH")
 
-    [[ "$version" -eq 3 ]]
+    [[ "$version" -eq 4 ]]
 }
 
 @test "新規DB: インデックス全7個が作成される" {

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -50,6 +50,13 @@ create_v1_db() {
     sqlite3 "$db_path" < "$PROJECT_ROOT/tests/fixtures/schema_v1.sql"
 }
 
+# v3 DB 作成（v3→v4 アップグレードテスト用）
+create_v3_db() {
+    local db_path="${1:-$TEST_TEMP_DIR/state/memory.db}"
+    mkdir -p "$(dirname "$db_path")"
+    sqlite3 "$db_path" < "$PROJECT_ROOT/tests/fixtures/schema_v3.sql"
+}
+
 # テーブルカラム名一覧を取得
 get_columns() {
     sqlite3 "$1" "PRAGMA table_info($2);" | cut -d'|' -f2 | sort


### PR DESCRIPTION
## Summary

- Leader の意図分類を LLM 任せから決定論的キーワードマッチングに変更し、`action_type` フィールドで下流に構造化伝搬
- Strategist に `action_type` → `task_type` 導出ルールを追加し、IGNITIAN が成果物の種類を構造的に判断可能に
- Coordinator に依存タスク追跡メカニズムを追加（`tasks.dependencies` カラム + 完了時の自動割り当て）
- DB スキーマ v3→v4 マイグレーション（`dependencies TEXT` カラム追加）

Closes #313

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `instructions/leader.md` | キーワード→action_type マッピングテーブル、github_ops 直接送信フロー |
| `instructions/strategist.md` | action_type 受信、task_type 導出ルール |
| `instructions/coordinator.md` | 依存タスク一括登録・自動割り当て、task_type 伝搬 |
| `instructions/ignitian.md` | task_type フィールドのドキュメント |
| `scripts/schema.sql` | tasks テーブルに `dependencies TEXT` カラム追加 |
| `scripts/schema_migrate.sh` | v3→v4 マイグレーション追加 |
| `tests/test_db_migration.bats` | v3→v4 マイグレーションテスト 6 件追加 |
| `tests/fixtures/schema_v3.sql` | v3 スキーマフィクスチャ新規作成 |
| `tests/test_helper.bash` | `create_v3_db()` ヘルパー関数追加 |
| `tests/test_db_init.bats` | user_version 期待値を 4 に更新 |

## Test plan

- [x] `bats --jobs "$(( $(nproc) * 8 ))" tests/` 全 170 テスト通過
- [x] v3 DB からの v4 マイグレーションが正しく動作することを確認
- [x] v1 DB から v4 まで一気にマイグレーションされることを確認
- [x] `grep -r 'action_type\|task_type' instructions/` で 4 ファイル全ての整合性確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)