### PR TITLE
fix: インストラクション間の断絶・矛盾を包括的に修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,8 +421,8 @@ sequenceDiagram
     A->>S: design_review_response
     E->>S: quality_plan_response
     I->>S: insight_response
-    S->>L: strategy_response
-    S->>C: task_list
+    S->>L: strategy_response (tasks含む)
+    L->>C: task_list (承認後)
     C->>IG: task_assignment
     IG->>C: task_completed
     C->>E: evaluation_request
@@ -451,6 +451,8 @@ IGNITEは **YAMLファイルキュー** と **SQLiteデータベース** の2層
 - **SQLite**: WALモードで並行アクセスに対応。全エージェントが学習・決定・タスク状態をセッション横断で記録し、再起動時の状態復元やMemory Insightsに活用
 
 詳細は [docs/architecture.md](docs/architecture.md) の「データストレージアーキテクチャ」セクションを参照してください。
+
+詳細なエージェント間通信フロー（implement/review/help_request 等）は [docs/communication-flow.md](docs/communication-flow.md) を参照してください。
 
 ## 📂 プロジェクト構造
 

--- a/README_en.md
+++ b/README_en.md
@@ -429,8 +429,8 @@ sequenceDiagram
     A->>S: design_review_response
     E->>S: quality_plan_response
     I->>S: insight_response
-    S->>L: strategy_response
-    S->>C: task_list
+    S->>L: strategy_response (includes tasks)
+    L->>C: task_list (after approval)
     C->>IG: task_assignment
     IG->>C: task_completed
     C->>E: evaluation_request
@@ -459,6 +459,8 @@ IGNITE manages data across two complementary layers: **YAML file queues** and a 
 - **SQLite**: Uses WAL mode for concurrent access. All agents record learnings, decisions, and task states across sessions, enabling state restoration on restart and Memory Insights analysis
 
 See the "Data Storage Architecture" section in [docs/architecture.md](docs/architecture.md) for details.
+
+For detailed agent communication flows (implement/review/help_request, etc.), see [docs/communication-flow_en.md](docs/communication-flow_en.md).
 
 ## 📂 Project Structure
 

--- a/docs/communication-flow.md
+++ b/docs/communication-flow.md
@@ -1,0 +1,154 @@
+# エージェント間コミュニケーションフロー
+
+IGNITE システムにおけるエージェント間のメッセージフローを図示します。
+
+## implement フロー全体図
+
+```mermaid
+sequenceDiagram
+    participant GW as GitHub Watcher
+    participant L as Leader (伊羽ユイ)
+    participant S as Strategist (義賀リオ)
+    participant A as Architect (祢音ナナ)
+    participant Ev as Evaluator (衣結ノア)
+    participant In as Innovator (恵那ツムギ)
+    participant C as Coordinator (通瀬アイナ)
+    participant I as IGNITIAN
+
+    GW->>L: github_task (implement)
+    Note over L: action_type 判定
+    L->>L: setup_repo.sh clone → ブランチ作成
+    L->>L: comment_on_issue.sh (受付応答)
+    L->>S: strategy_request (repository, issue_number, action_type)
+
+    Note over S: Sub-Leaders レビュー
+    S->>A: design_review_request
+    S->>Ev: quality_plan_request
+    S->>In: insight_request
+    A->>S: design_review_response
+    Ev->>S: quality_plan_response
+    In->>S: insight_response
+
+    S->>L: strategy_response (strategy + tasks[])
+    Note over L: 承認判断
+
+    L->>C: task_list (承認済み tasks, repository, issue_number)
+    Note over C: action_type を記録
+
+    C->>I: task_assignment (repository, issue_number)
+    Note over I: setup_repo.sh clone → per-IGNITIAN clone
+    Note over I: 実装 + commit + push
+    I->>C: task_completed
+
+    Note over C: 全 implement 完了 → create_pr 配分
+    C->>I: task_assignment (create_pr)
+    Note over I: create_pr.sh → PR 作成
+    I->>C: task_completed (pr_url)
+
+    C->>L: progress_update (pr_url)
+    L->>L: comment_on_issue.sh (完了コメント)
+```
+
+## review フロー
+
+```mermaid
+sequenceDiagram
+    participant L as Leader
+    participant S as Strategist
+    participant C as Coordinator
+    participant I as IGNITIAN
+
+    Note over L: github_task (review) 受信
+    L->>S: strategy_request (action_type: review)
+    S->>L: strategy_response (review タスク群)
+    L->>C: task_list (review タスク)
+    C->>I: task_assignment (review)
+    Note over I: レビュー実施
+    Note over I: comment_on_issue.sh で結果を GitHub に投稿
+    I->>C: task_completed
+    C->>L: progress_update (全タスク完了)
+    Note over L: サマリーコメントを GitHub に投稿
+```
+
+## help_request / help_ack リレー
+
+```mermaid
+sequenceDiagram
+    participant I as IGNITIAN
+    participant C as Coordinator
+    participant L as Leader
+
+    I->>C: help_request (task_id, help_type)
+    C->>I: help_ack (action: investigating)
+    Note over C: severity 判定
+    C->>L: help_request_forwarded (severity: high)
+    Note over L: 対処方針を決定
+    L->>C: help_ack (relay_to: ignitian_{n}, action: resolved)
+    C->>I: help_ack (guidance: 対処方針)
+    Note over I: 作業再開
+```
+
+## issue_proposal リレー
+
+```mermaid
+sequenceDiagram
+    participant I as IGNITIAN
+    participant C as Coordinator
+    participant L as Leader
+
+    I->>C: issue_proposal (severity, evidence)
+    Note over C: severity フィルタリング
+    C->>I: issue_proposal_ack (decision: received)
+    alt severity: critical / major
+        C->>L: issue_proposal_forwarded
+        Note over L: 判断 (起票/追記/却下)
+        L->>C: issue_proposal_ack (decision: created, issue_url)
+        C->>I: issue_proposal_ack (decision: created, issue_url)
+    else severity: minor / suggestion
+        Note over C: ログ記録のみ
+    end
+```
+
+## メッセージタイプ一覧
+
+### Leader 発信
+
+| メッセージタイプ | 送信先 | 用途 |
+|---|---|---|
+| `strategy_request` | Strategist | 戦略立案依頼 |
+| `task_list` | Coordinator | タスク配分指示（Strategist 承認後） |
+| `revision_request` | Strategist | 戦略の差し戻し |
+| `help_ack` | Coordinator / Sub-Leader | ヘルプ要求への応答 |
+| `issue_proposal_ack` | Coordinator / Sub-Leader | Issue提案への応答 |
+| `improvement_request` | Innovator | 改善実行の指示 |
+| `improvement_suggestion_ack` | Innovator | 改善提案への応答 |
+
+### Strategist 発信
+
+| メッセージタイプ | 送信先 | 用途 |
+|---|---|---|
+| `strategy_response` | Leader | 戦略提案（tasks 配列含む） |
+| `design_review_request` | Architect | 設計レビュー依頼 |
+| `quality_plan_request` | Evaluator | 品質プラン依頼 |
+| `insight_request` | Innovator | インサイト依頼 |
+
+### Coordinator 発信
+
+| メッセージタイプ | 送信先 | 用途 |
+|---|---|---|
+| `task_assignment` | IGNITIAN | タスク割り当て |
+| `revision_request` | IGNITIAN | 成果物の差し戻し |
+| `progress_update` | Leader | 進捗報告（PR URL 含む場合あり） |
+| `help_ack` | IGNITIAN | ヘルプ要求への応答（Leader からのリレー含む） |
+| `help_request_forwarded` | Leader | IGNITIAN のヘルプ要求を転送 |
+| `issue_proposal_ack` | IGNITIAN | Issue提案への応答（Leader からのリレー含む） |
+| `issue_proposal_forwarded` | Leader | IGNITIAN の Issue 提案を転送 |
+| `evaluation_request` | Evaluator | 判断困難ケースの相談 |
+
+### IGNITIAN 発信
+
+| メッセージタイプ | 送信先 | 用途 |
+|---|---|---|
+| `task_completed` | Coordinator | タスク完了報告 |
+| `help_request` | Coordinator | ヘルプ要求 |
+| `issue_proposal` | Coordinator | Issue 提案 |

--- a/docs/communication-flow_en.md
+++ b/docs/communication-flow_en.md
@@ -1,0 +1,154 @@
+# Agent Communication Flow
+
+This document illustrates the message flow between agents in the IGNITE system.
+
+## Implement Flow (Full)
+
+```mermaid
+sequenceDiagram
+    participant GW as GitHub Watcher
+    participant L as Leader (Yui Iha)
+    participant S as Strategist (Rio Giga)
+    participant A as Architect (Nana Neon)
+    participant Ev as Evaluator (Noah Iyui)
+    participant In as Innovator (Tsumugi Ena)
+    participant C as Coordinator (Aina Tsuse)
+    participant I as IGNITIAN
+
+    GW->>L: github_task (implement)
+    Note over L: Determine action_type
+    L->>L: setup_repo.sh clone → create branch
+    L->>L: comment_on_issue.sh (acknowledge)
+    L->>S: strategy_request (repository, issue_number, action_type)
+
+    Note over S: Sub-Leaders review
+    S->>A: design_review_request
+    S->>Ev: quality_plan_request
+    S->>In: insight_request
+    A->>S: design_review_response
+    Ev->>S: quality_plan_response
+    In->>S: insight_response
+
+    S->>L: strategy_response (strategy + tasks[])
+    Note over L: Approval decision
+
+    L->>C: task_list (approved tasks, repository, issue_number)
+    Note over C: Record action_type
+
+    C->>I: task_assignment (repository, issue_number)
+    Note over I: setup_repo.sh clone → per-IGNITIAN clone
+    Note over I: Implement + commit + push
+    I->>C: task_completed
+
+    Note over C: All implement tasks done → assign create_pr
+    C->>I: task_assignment (create_pr)
+    Note over I: create_pr.sh → Create PR
+    I->>C: task_completed (pr_url)
+
+    C->>L: progress_update (pr_url)
+    L->>L: comment_on_issue.sh (completion comment)
+```
+
+## Review Flow
+
+```mermaid
+sequenceDiagram
+    participant L as Leader
+    participant S as Strategist
+    participant C as Coordinator
+    participant I as IGNITIAN
+
+    Note over L: github_task (review) received
+    L->>S: strategy_request (action_type: review)
+    S->>L: strategy_response (review tasks)
+    L->>C: task_list (review tasks)
+    C->>I: task_assignment (review)
+    Note over I: Conduct review
+    Note over I: Post results to GitHub via comment_on_issue.sh
+    I->>C: task_completed
+    C->>L: progress_update (all tasks completed)
+    Note over L: Post summary comment to GitHub
+```
+
+## help_request / help_ack Relay
+
+```mermaid
+sequenceDiagram
+    participant I as IGNITIAN
+    participant C as Coordinator
+    participant L as Leader
+
+    I->>C: help_request (task_id, help_type)
+    C->>I: help_ack (action: investigating)
+    Note over C: Severity assessment
+    C->>L: help_request_forwarded (severity: high)
+    Note over L: Determine resolution
+    L->>C: help_ack (relay_to: ignitian_{n}, action: resolved)
+    C->>I: help_ack (guidance: resolution)
+    Note over I: Resume work
+```
+
+## issue_proposal Relay
+
+```mermaid
+sequenceDiagram
+    participant I as IGNITIAN
+    participant C as Coordinator
+    participant L as Leader
+
+    I->>C: issue_proposal (severity, evidence)
+    Note over C: Severity filtering
+    C->>I: issue_proposal_ack (decision: received)
+    alt severity: critical / major
+        C->>L: issue_proposal_forwarded
+        Note over L: Decision (create/append/reject)
+        L->>C: issue_proposal_ack (decision: created, issue_url)
+        C->>I: issue_proposal_ack (decision: created, issue_url)
+    else severity: minor / suggestion
+        Note over C: Log only
+    end
+```
+
+## Message Type Reference
+
+### Leader Outbound
+
+| Message Type | Destination | Purpose |
+|---|---|---|
+| `strategy_request` | Strategist | Request strategy planning |
+| `task_list` | Coordinator | Task distribution (after Strategist approval) |
+| `revision_request` | Strategist | Strategy revision request |
+| `help_ack` | Coordinator / Sub-Leader | Response to help request |
+| `issue_proposal_ack` | Coordinator / Sub-Leader | Response to issue proposal |
+| `improvement_request` | Innovator | Request improvement execution |
+| `improvement_suggestion_ack` | Innovator | Response to improvement suggestion |
+
+### Strategist Outbound
+
+| Message Type | Destination | Purpose |
+|---|---|---|
+| `strategy_response` | Leader | Strategy proposal (includes tasks array) |
+| `design_review_request` | Architect | Design review request |
+| `quality_plan_request` | Evaluator | Quality plan request |
+| `insight_request` | Innovator | Insight request |
+
+### Coordinator Outbound
+
+| Message Type | Destination | Purpose |
+|---|---|---|
+| `task_assignment` | IGNITIAN | Task assignment |
+| `revision_request` | IGNITIAN | Deliverable revision request |
+| `progress_update` | Leader | Progress report (may include PR URL) |
+| `help_ack` | IGNITIAN | Help request response (including relay from Leader) |
+| `help_request_forwarded` | Leader | Forward IGNITIAN help request |
+| `issue_proposal_ack` | IGNITIAN | Issue proposal response (including relay from Leader) |
+| `issue_proposal_forwarded` | Leader | Forward IGNITIAN issue proposal |
+| `evaluation_request` | Evaluator | Consultation for ambiguous cases |
+
+### IGNITIAN Outbound
+
+| Message Type | Destination | Purpose |
+|---|---|---|
+| `task_completed` | Coordinator | Task completion report |
+| `help_request` | Coordinator | Help request |
+| `issue_proposal` | Coordinator | Issue proposal |

--- a/instructions/leader.md
+++ b/instructions/leader.md
@@ -71,6 +71,8 @@ priority: high
 payload:
   goal: "READMEファイルを作成する"
   action_type: "implement"    # implement / review / explain / insights / github_ops
+  repository: "owner/repo"
+  issue_number: 123
   requirements:
     - "プロジェクト概要を記載"
     - "インストール方法を記載"
@@ -277,6 +279,8 @@ payload:
    payload:
      goal: "シンプルなCLIツールを実装する"
      action_type: "implement"
+     repository: "owner/repo"
+     issue_number: 123
      request: "この目標を達成するための戦略とタスク分解を行ってください"
    EOF
    # send_message.sh で MIME メッセージとして送信
@@ -299,14 +303,26 @@ payload:
    to: leader
    payload:
      strategy: "3フェーズで実装"
-     tasks: [...]
+     repository: "owner/repo"
+     issue_number: 123
+     action_type: "implement"
+     tasks:
+       - task_id: "task_001"
+         title: "README骨組み作成"
+         # ... タスク詳細
    ```
 
+   > **重要**: strategy_response には `tasks` 配列が含まれる。Strategist は strategy_response を **Leader のみ** に送信する（Coordinator への直接送信はしない）。
+
 2. **評価と判断**
-   - 提案された戦略を確認
+   - 提案された戦略とタスクリストを確認
    - 妥当性を判断
 
-3. **承認と次のステップ**
+3. **承認と Coordinator への task_list 送信**
+
+   Leader が strategy_response を承認した場合、**Leader が** Coordinator に `task_list` を送信する。
+   この task_list が唯一の正式なタスク配分指示である（Strategist は Coordinator に直接送信しない）。
+
    ```bash
    # ボディYAMLをファイルに書き出し
    cat > .ignite/tmp/body.yaml << 'EOF'
@@ -315,7 +331,10 @@ payload:
    to: coordinator
    payload:
      approved: true
-     tasks: [...]
+     action_type: "implement"
+     repository: "owner/repo"
+     issue_number: 123
+     tasks: [...]   # strategy_response の tasks をそのまま転送
    EOF
    # send_message.sh で MIME メッセージとして送信
    ./scripts/utils/send_message.sh task_list leader coordinator --body-file .ignite/tmp/body.yaml
@@ -446,7 +465,7 @@ payload:
    - **複合リクエスト**: 意図を分解し、適切な順序で逐次実行
      - 例: 「レビューして問題があれば修正して」→ レビュー → 問題発見時は修正 → PR 作成
      - 例: 「コードレビューをして、指摘事項があれば修正してレポートしてください」→ レビュー → 修正 → レポートコメント
-4. 実装完了後、`./scripts/utils/create_pr.sh` で PR 作成
+4. 実装完了後、PR作成は Strategist が task_list に含める `create_pr` タスクにより、Coordinator → IGNITIAN 経由で自動実行される。Leader は Coordinator からの `progress_update`（PR URL 含む）を受け取り、完了コメントを投稿する
 5. 結果を Bot 名義で Issue/PR にコメント
 
 **実装タスクの例:**
@@ -517,12 +536,12 @@ github_task 起点のタスクでは、結果は**必ずGitHub上に出力**す�
 - **.ignite/ の構造改変禁止**: `.ignite/` はシステム管理ディレクトリ。内部のファイル・ディレクトリの移動・リネーム・削除・シンボリックリンク作成を行わない。読み取りと、指定された手段（`send_message.sh` / `.ignite/tmp/` への一時ファイル書き込み）のみ許可
 
 #### 例外: implement トリガー
-- `repo_path` 内でのコード編集・ファイル追加は許可（PR用のコード変更）
+- IGNITIAN が per-IGNITIAN clone 内でコード編集・ファイル追加・commit+push を行う（PR用のコード変更）
 - ただしコード変更の説明・レビュー依頼等のドキュメントはGitHubコメントに書く
 
 #### 例外: insights トリガー
-- `repo_path` のcloneは許可（分析のための読み取り用）
-- 分析結果ファイルは `repo_path` 内にも `workspace/` にも作成しない
+- リポジトリの clone は許可（分析のための読み取り用）
+- 分析結果ファイルはリポジトリ clone 内にも `workspace/` にも作成しない
 - 分析結果は全てGitHubコメントまたは新規Issue として出力する
 
 #### trigger別の例外ケース
@@ -531,7 +550,7 @@ github_task 起点のタスクでは、結果は**必ずGitHub上に出力**す�
 |:--------|:-------------------|:-----------|
 | explain | 禁止 | Issue コメント |
 | review | 禁止 | Issue コメント |
-| implement | repo_path内のみ許可 | PR + コメント |
+| implement | per-IGNITIAN clone内のみ許可 | PR + コメント |
 | insights | 禁止 | Issue コメント or 新規Issue |
 
 #### アンチパターン
@@ -584,19 +603,18 @@ BOT_TOKEN=$(./scripts/utils/get_github_app_token.sh --repo {repository})
    - タスクの分解と実装方針を決定
    - 作業ディレクトリは `$REPO_PATH` を使用
 
-4. **IGNITIANsにタスクを配分**
-   - タスクメッセージに `repo_path` を含める
+4. **Strategist に実装戦略を依頼**
+   - `strategy_request` に `repository` と `issue_number` を含める（`repo_path` は渡さない）
+   - IGNITIAN は `setup_repo.sh clone` で自分の per-IGNITIAN 作業パスを取得する
    ```yaml
    payload:
-     repo_path: "{repo_path}"
+     repository: "{repository}"
      issue_number: {issue_number}
    ```
 
-5. **実装完了後、PR作成**
-   ```bash
-   cd "$REPO_PATH"
-   ./scripts/utils/create_pr.sh {issue_number} --repo {repository} --bot
-   ```
+5. **Leader 承認後、Coordinator に task_list を送信**
+   - Strategist の strategy_response に含まれる tasks（末尾に create_pr タスク含む）を Coordinator に転送
+   - PR 作成は create_pr タスクを受け取った IGNITIAN が `create_pr.sh` で実行
 
 6. **完了応答を投稿**
    ```bash
@@ -762,21 +780,23 @@ payload:
 
 ### review トリガー処理
 
-PRに対して `@ignite-gh-app review` が来た場合：
+PRに対して `@ignite-gh-app review` が来た場合も、implement と同様に Strategist → Coordinator → IGNITIAN フローで処理する:
 
-1. **PRの差分を取得**
-   ```bash
-   github_api_get "{repository}" "/repos/{repository}/pulls/{pr_number}" | jq -r '.diff_url'
-   # または git diff で取得
+1. **Strategist に review 用 `strategy_request` を送信**
+   ```yaml
+   payload:
+     goal: "PR #{pr_number} のコードレビュー"
+     action_type: "review"
+     repository: "{repository}"
+     issue_number: {pr_number}
    ```
 
-2. **IGNITIANsにレビューと説明を依頼**
-   - コード品質の確認
-   - バグの可能性の指摘
-   - 改善提案
-   - 変更内容の要約と解説
+2. **Strategist が review タスクリストを作成**
+   - 各タスクの `instructions` に `comment_on_issue.sh --bot` でGitHubにレビュー結果を投稿する手順を含める
 
-3. **レビュー結果をPRコメントとして投稿**
+3. **Leader 承認後 Coordinator に `task_list` 配分**
+
+4. **完了コメントのフォーマット参考例**
    ```bash
    ./scripts/utils/comment_on_issue.sh {pr_number} --repo {repository} --bot \
      --body "## コードレビュー
@@ -793,6 +813,54 @@ PRに対して `@ignite-gh-app review` が来た場合：
 ---
 *Generated by IGNITE AI Team*"
    ```
+
+## progress_update 受信後の処理フロー
+
+Coordinator から `progress_update` を受信した場合、`action_type` と payload の内容に応じて以下のアクションを実行する:
+
+| action_type | 条件 | Leader のアクション |
+|---|---|---|
+| `implement` | `pr_url` あり | `comment_on_issue.sh` で PR URL を含む完了コメントを Issue に投稿 |
+| `implement` | `pr_url` なし（途中経過） | ダッシュボードに進捗を記録。GitHub コメントは不要 |
+| `review` | 全タスク完了 | `comment_on_issue.sh` でレビュー結果サマリーを Issue/PR に投稿 |
+| `explain` | 全タスク完了 | `comment_on_issue.sh` で説明を Issue に投稿 |
+| `insights` | 全タスク完了 | 内部メモとして保持（GitHub 投稿不要） |
+| いずれか | エラー/失敗報告 | エラー内容を `comment_on_issue.sh --template error` で Issue にコメント + リトライ判断 |
+
+**implement 完了時の処理例:**
+```bash
+# Coordinator からの progress_update に pr_url が含まれている場合
+./scripts/utils/comment_on_issue.sh {issue_number} --repo {repository} --bot \
+  --template success --context "PR #{pr_number} を作成しました: {pr_url}"
+```
+
+## Sub-Leader 応答タイムアウトガイドライン
+
+Sub-Leader からの応答待ち目安時間:
+
+| メッセージ | 目安時間 |
+|---|---|
+| `strategy_response` | 10分以内 |
+| `architecture_response` | 5分以内 |
+| `evaluation_result` | 5分以内 |
+
+**タイムアウト時のリカバリ:**
+1. Sub-Leader に `ping` メッセージを送信
+2. 応答がなければ、同じ request を再送信
+3. 2回目も応答がなければ、ダッシュボードに記録しユーザーに報告
+
+## improvement_suggestion 受信時の処理
+
+Innovator からの `improvement_suggestion` を受信した場合の処理フロー:
+
+1. **提案内容を評価**: 実現可能性、優先度、リスクを判断
+2. **判断に応じたアクション**:
+
+| 判断 | アクション |
+|---|---|
+| **承認** | Innovator に `improvement_request` で実行を指示 |
+| **却下** | Innovator に理由を付けて `improvement_suggestion_ack(decision: rejected)` を返信 |
+| **保留** | ダッシュボードに記録し後で判断 |
 
 ## 5回セルフレビュープロトコル
 
@@ -892,6 +960,7 @@ Coordinator（IGNITIAN経由）または Sub-Leaders から help_request を受�
    priority: high
    payload:
      task_id: "{task_id}"
+     relay_to: "ignitian_{n}"    # Coordinator がリレーする宛先 IGNITIAN
      original_help_type: "{help_type}"
      action: investigating   # investigating | reassigning | escalating | resolved
      guidance: |


### PR DESCRIPTION
## Summary

- Issue #287（PR作成の責務空白）を直接原因として、包括的レビューで発見した**15の断絶ポイント**を一括修正
- Strategist → Coordinator 直接送信を廃止し、Leader 承認後の task_list 一本化フローに統一
- IGNITIAN が per-IGNITIAN clone で commit+push する新フローを定義
- implement タスクリスト末尾に `create_pr` タスクを必須化
- help_ack / issue_proposal_ack のリレーチェーン断絶を修正
- コミュニケーションパス図ドキュメント（Mermaid）を新規作成

### 断絶ポイント対応表

| # | 断絶 | 修正箇所 |
|---|------|----------|
| 1 | PR作成の責務空白 | leader.md, strategist.md, coordinator.md, ignitian.md |
| 2 | repo_path の per-IGNITIAN 矛盾 | leader.md, ignitian.md |
| 3 | task_list 二重送信 | strategist.md, leader.md |
| 4 | action_type 完了後ワークフロー未定義 | coordinator.md |
| 5 | GitHub 出力先ルール配置ミス | strategist.md |
| 6 | strategy_request 例示不整合 | leader.md |
| 7 | IGNITIAN commit/push 未定義 | ignitian.md |
| 8 | progress_update ハンドラ未定義 | leader.md |
| 9 | review トリガー Coordinator 迂回 | leader.md |
| 10 | help_ack リレー断絶 | leader.md, coordinator.md |
| 11 | Sub-Leader タイムアウト未定義 | leader.md |
| 12 | strategy_response に tasks なし | strategist.md |
| 13 | improvement_suggestion ハンドラなし | leader.md |
| 14 | Architect→Strategist revision_request | strategist.md |
| 15 | issue_proposal_ack リレーなし | coordinator.md |

## Test plan

- [x] `bats --jobs "$(( $(nproc) * 8 ))" tests/` — 全207テストパス
- [x] `grep -rn 'to: coordinator' instructions/strategist.md` — Strategist→Coordinator 直接送信が削除されていること
- [x] `grep -rn 'from: strategist' instructions/coordinator.md` — Coordinator が Strategist からの直接受信を期待していないこと
- [x] README のシーケンス図で `S->>C` が `L->>C` に修正されていること
- [x] インストール先 (`~/.local/share/ignite/instructions/`) への同期完了

Closes #287

🤖 Generated with [Claude Code](https://claude.com/claude-code)