### PR TITLE
fix: queue_monitor のワークスペース間ロック共有によるシーソー停止を修正

### DIFF
--- a/scripts/lib/cmd_service.sh
+++ b/scripts/lib/cmd_service.sh
@@ -404,6 +404,7 @@ ENVEOF
         echo "" >> "$env_file"
         echo "# ワークスペースパス（systemd 起動時に使用）" >> "$env_file"
         echo "IGNITE_WORKSPACE=${_workspace_dir}" >> "$env_file"
+        echo "WORKSPACE_DIR=${_workspace_dir}" >> "$env_file"
     fi
 
     # パーミッション設定

--- a/scripts/utils/queue_monitor.sh
+++ b/scripts/utils/queue_monitor.sh
@@ -29,6 +29,11 @@ source "${LIB_DIR}/cli_provider.sh"
 source "${LIB_DIR}/health_check.sh"
 source "${LIB_DIR}/agent.sh"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# systemd 環境変数 IGNITE_WORKSPACE → WORKSPACE_DIR 変換
+# env.%i は IGNITE_WORKSPACE を設定するが、core.sh は WORKSPACE_DIR を参照する
+if [[ -z "${WORKSPACE_DIR:-}" ]] && [[ -n "${IGNITE_WORKSPACE:-}" ]]; then
+    WORKSPACE_DIR="$IGNITE_WORKSPACE"
+fi
 [[ -n "${WORKSPACE_DIR:-}" ]] && setup_workspace_config "$WORKSPACE_DIR"
 
 # グレースフル停止用フラグ（trap内ではフラグを立てるだけ、exit()を呼ばない）


### PR DESCRIPTION
## Summary

- systemd の `ignite-monitor@.service` から起動される `queue_monitor.sh` が `IGNITE_WORKSPACE` 環境変数を認識せず、全ワークスペースのモニターが同一のデフォルトパス（`~/.local/share/ignite/workspace/state/queue_monitor.lock`）をロックファイルとして使用していた
- `flock -n` の排他制御により1インスタンスしか起動できず、別ワークスペースのサービス起動時にシーソー的に他のモニターが落ちる問題を修正
- `cmd_service.sh` の env ファイル生成時に `WORKSPACE_DIR` も出力するよう改善（新規セットアップ用）

## Test plan

- [x] `IGNITE_WORKSPACE` のみ設定時に `WORKSPACE_DIR` に正しく変換されること
- [x] `WORKSPACE_DIR` が既に設定済みの場合は上書きしないこと
- [x] 異なるワークスペースのモニターが独立したロックファイルを使用すること
- [x] 同一ワークスペースの二重起動は従来通りブロックされること
- [x] bats 全テスト（207件）パス済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)